### PR TITLE
Ensure scheduled calls pass phone number to background isolate

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,7 +18,15 @@ Future<void> requestPermissions() async {
 }
 
 // Background call
-Future<void> backgroundCall(String phoneNumber) async {
+@pragma('vm:entry-point')
+Future<void> backgroundCall(dynamic parameter) async {
+  final String? phoneNumber = parameter as String?;
+
+  if (phoneNumber == null || phoneNumber.isEmpty) {
+    debugPrint('⚠️ No phone number provided to backgroundCall');
+    return;
+  }
+
   final Uri telUri = Uri(scheme: 'tel', path: phoneNumber);
 
   if (await Permission.phone.isGranted) {
@@ -117,8 +125,9 @@ class _CallSchedulerScreenState extends State<CallSchedulerScreen> {
     await AndroidAlarmManager.oneShot(
       delay,
       DateTime.now().millisecondsSinceEpoch ~/ 1000,
-      () => backgroundCall(_phoneController.text),
+      backgroundCall,
       wakeup: true,
+      params: _phoneController.text,
     );
 
     if (!mounted) return;


### PR DESCRIPTION
## Summary
- annotate the backgroundCall function as a VM entry-point so the alarm isolate can locate it
- accept a dynamic parameter in backgroundCall and guard against missing phone numbers
- pass the scheduled phone number to AndroidAlarmManager.oneShot via params instead of an inline closure

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d63c5ee838832c9d4bca76701be1b4