### PR TITLE
Fix alarm manager callback parameters

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,7 +18,14 @@ Future<void> requestPermissions() async {
 }
 
 // Background call
-Future<void> backgroundCall(String phoneNumber) async {
+Future<void> backgroundCall(Map<String, dynamic>? params) async {
+  final String? phoneNumber = params?['phoneNumber'] as String?;
+
+  if (phoneNumber == null || phoneNumber.isEmpty) {
+    debugPrint('⚠️ No phone number provided for background call.');
+    return;
+  }
+
   final Uri telUri = Uri(scheme: 'tel', path: phoneNumber);
 
   if (await Permission.phone.isGranted) {
@@ -117,8 +124,9 @@ class _CallSchedulerScreenState extends State<CallSchedulerScreen> {
     await AndroidAlarmManager.oneShot(
       delay,
       DateTime.now().millisecondsSinceEpoch ~/ 1000,
-      () => backgroundCall(_phoneController.text),
+      backgroundCall,
       wakeup: true,
+      params: {'phoneNumber': _phoneController.text},
     );
 
     if (!mounted) return;


### PR DESCRIPTION
## Summary
- pass the scheduled phone number to `AndroidAlarmManager.oneShot` via the params map
- update `backgroundCall` to handle the params payload and guard against missing phone numbers

## Testing
- `flutter analyze` *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d63e7bd990832c95f9c7e28767887d