### PR TITLE
Add caching to Flutter CI workflow

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -20,6 +20,33 @@ jobs:
           flutter-version: "3.35.4"
           channel: "stable"
 
+      - name: Cache Pub dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle
+          key: ${{ runner.os }}-gradle-${{ hashFiles('android/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Cache Android SDK components
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.android
+          key: ${{ runner.os }}-android-${{ hashFiles('android/app/build.gradle') }}
+          restore-keys: |
+            ${{ runner.os }}-android-
+
       - name: Install dependencies
         run: flutter pub get
 


### PR DESCRIPTION
## Summary
- add cache steps for Flutter pub packages, Gradle, and Android SDK components
- ensure caches are restored before dependency installation in the workflow

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d6407357ac832c81c908ee9e36eb19