### PR TITLE
Add internet permissions to Android manifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
         android:label="girlfriend_call_app"


### PR DESCRIPTION
## Summary
- add internet and network state permissions to the Android manifest so FlutterMap tiles can load

## Testing
- `flutter build apk` *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c4f09514832cbcd65afc5faa0657