### PR TITLE
Fix background alarm callback for scheduled calls

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,7 +20,16 @@ Future<void> requestPermissions() async {
 }
 
 // Background call
+@pragma('vm:entry-point')
+Future<void> _triggerCall(dynamic params) async {
+  if (params is! Map) {
+    debugPrint('⚠️ Invalid parameters received for scheduled call: $params');
+    return;
+  }
 
+  final phoneNumber = (params as Map)['phoneNumber'] as String?;
+  if (phoneNumber == null || phoneNumber.isEmpty) {
+    debugPrint('⚠️ No phone number provided for scheduled call.');
     return;
   }
 
@@ -157,7 +166,8 @@ class _CallSchedulerScreenState extends State<CallSchedulerScreen> {
     final alarmId = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     await AndroidAlarmManager.oneShot(
       delay,
-
+      alarmId,
+      _triggerCall,
       params: {'phoneNumber': _phoneController.text},
     );
 


### PR DESCRIPTION
## Summary
- add a vm entry-point background callback to place or open scheduled phone calls
- validate callback parameters before launching the dialer and keep existing debug logging
- wire the alarm manager to invoke the new callback when scheduling calls

## Testing
- dart format lib/main.dart *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c6c8ce68832c83f6fbf8ad8ddc3b