### PR TITLE
Refine scheduled call parameter handling

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,12 +22,12 @@ Future<void> requestPermissions() async {
 // Background call
 @pragma('vm:entry-point')
 Future<void> _triggerCall(dynamic params) async {
-  if (params is! Map) {
+  if (params is! Map<String, dynamic>) {
     debugPrint('⚠️ Invalid parameters received for scheduled call: $params');
     return;
   }
 
-  final phoneNumber = (params as Map)['phoneNumber'] as String?;
+  final phoneNumber = params['phoneNumber'] as String?;
   if (phoneNumber == null || phoneNumber.isEmpty) {
     debugPrint('⚠️ No phone number provided for scheduled call.');
     return;


### PR DESCRIPTION
## Summary
- tighten scheduled call parameter validation by requiring a typed map and simplifying phone number extraction

## Testing
- `flutter analyze` *(fails: `flutter` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68daa2cadae4832ca2b1ea91b884c8ae