### PR TITLE
Load remote callee location before scheduled calls

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,13 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:android_alarm_manager_plus/android_alarm_manager_plus.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter_map/flutter_map.dart';
-import 'package:latlong2/latlong.dart';
-import 'package:url_launcher/url_launcher.dart';
-import 'package:permission_handler/permission_handler.dart';
 import 'package:geolocator/geolocator.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
   await AndroidAlarmManager.initialize();
   await requestPermissions();
   runApp(const MyApp());
@@ -22,6 +26,16 @@ Future<void> requestPermissions() async {
 // Background call
 @pragma('vm:entry-point')
 Future<void> _triggerCall(dynamic params) async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  if (Firebase.apps.isEmpty) {
+    try {
+      await Firebase.initializeApp();
+    } catch (error) {
+      debugPrint('⚠️ Failed to initialize Firebase in background: $error');
+    }
+  }
+
   if (params is! Map<String, dynamic>) {
     debugPrint('⚠️ Invalid parameters received for scheduled call: $params');
     return;
@@ -31,6 +45,52 @@ Future<void> _triggerCall(dynamic params) async {
   if (phoneNumber == null || phoneNumber.isEmpty) {
     debugPrint('⚠️ No phone number provided for scheduled call.');
     return;
+  }
+
+  final String? sharedUserIdParam = params['sharedUserId'] as String?;
+  final double? remoteLatParam =
+      (params['remoteLat'] is num) ? (params['remoteLat'] as num).toDouble() : null;
+  final double? remoteLngParam =
+      (params['remoteLng'] is num) ? (params['remoteLng'] as num).toDouble() : null;
+
+  final SharedPreferences prefs = await SharedPreferences.getInstance();
+  RemoteLocationData? cachedRemote = _remoteLocationFromPrefs(prefs);
+  RemoteLocationData? remoteLocation;
+
+  final String? querySharedId = sharedUserIdParam ??
+      cachedRemote?.sharedUserId ??
+      prefs.getString(_prefsRemoteSharedUserIdKey);
+
+  try {
+    remoteLocation = await fetchRemoteLocationForPhone(
+      phoneNumber,
+      sharedUserId: querySharedId,
+    );
+  } catch (error) {
+    debugPrint('⚠️ Error fetching remote location in background: $error');
+  }
+
+  if (remoteLocation == null && remoteLatParam != null && remoteLngParam != null) {
+    remoteLocation = RemoteLocationData(
+      latitude: remoteLatParam,
+      longitude: remoteLngParam,
+      lastUpdated: DateTime.now(),
+      sharedUserId: querySharedId,
+    );
+  }
+
+  remoteLocation ??= cachedRemote;
+
+  if (remoteLocation != null) {
+    await persistRemoteLocation(remoteLocation, prefs: prefs);
+    final String staleSuffix = remoteLocation.isStale ? ' (stale)' : '';
+    debugPrint(
+      'ℹ️ Remote location for $phoneNumber: '
+      '${remoteLocation.latitude.toStringAsFixed(5)}, '
+      '${remoteLocation.longitude.toStringAsFixed(5)}$staleSuffix',
+    );
+  } else {
+    debugPrint('⚠️ No remote location available for $phoneNumber');
   }
 
   final Uri telUri = Uri(scheme: 'tel', path: phoneNumber);
@@ -64,6 +124,311 @@ Future<Position> getCurrentLocation() async {
   return Geolocator.getCurrentPosition(locationSettings: locationSettings);
 }
 
+const List<String> _remoteLocationCollections = <String>[
+  'calleeLocations',
+  'remoteLocations',
+  'users',
+];
+
+const Duration _remoteLocationStaleDuration = Duration(minutes: 15);
+const String _prefsRemoteLatKey = 'remoteLocation.lat';
+const String _prefsRemoteLngKey = 'remoteLocation.lng';
+const String _prefsRemoteUpdatedAtKey = 'remoteLocation.updatedAt';
+const String _prefsRemoteSharedUserIdKey = 'remoteLocation.sharedUserId';
+
+class RemoteLocationData {
+  const RemoteLocationData({
+    required this.latitude,
+    required this.longitude,
+    this.lastUpdated,
+    this.sharedUserId,
+  });
+
+  final double latitude;
+  final double longitude;
+  final DateTime? lastUpdated;
+  final String? sharedUserId;
+
+  bool get isStale =>
+      lastUpdated != null &&
+      DateTime.now().difference(lastUpdated!) > _remoteLocationStaleDuration;
+}
+
+String _sanitizePhoneNumber(String value) {
+  return value.replaceAll(RegExp(r'[^0-9+]'), '');
+}
+
+double? _toDouble(dynamic value) {
+  if (value is double) {
+    return value;
+  }
+  if (value is int) {
+    return value.toDouble();
+  }
+  if (value is num) {
+    return value.toDouble();
+  }
+  if (value is String) {
+    return double.tryParse(value);
+  }
+  return null;
+}
+
+DateTime? _parseTimestamp(dynamic value) {
+  if (value is Timestamp) {
+    return value.toDate();
+  }
+  if (value is DateTime) {
+    return value;
+  }
+  if (value is String) {
+    return DateTime.tryParse(value);
+  }
+  if (value is num) {
+    final int numericValue = value.toInt();
+    if (numericValue > 1000000000000) {
+      return DateTime.fromMillisecondsSinceEpoch(numericValue);
+    }
+    if (numericValue > 1000000000) {
+      return DateTime.fromMillisecondsSinceEpoch(numericValue * 1000);
+    }
+    return DateTime.fromMillisecondsSinceEpoch(numericValue);
+  }
+  return null;
+}
+
+RemoteLocationData? _documentToRemoteLocation(
+  DocumentSnapshot<Map<String, dynamic>> snapshot,
+) {
+  final Map<String, dynamic>? data = snapshot.data();
+  if (data == null) {
+    return null;
+  }
+
+  double? latitude = _toDouble(data['lat'] ?? data['latitude'] ?? data['y']);
+  double? longitude =
+      _toDouble(data['lng'] ?? data['longitude'] ?? data['long'] ?? data['lon']);
+
+  final dynamic latLngField = data['latLng'];
+  if ((latitude == null || longitude == null) && latLngField is Map) {
+    final Map<dynamic, dynamic> latLngMap = latLngField;
+    latitude ??= _toDouble(latLngMap['lat'] ?? latLngMap['latitude']);
+    longitude ??=
+        _toDouble(latLngMap['lng'] ?? latLngMap['longitude'] ?? latLngMap['long']);
+  }
+
+  final dynamic locationField =
+      data['location'] ?? data['position'] ?? data['geo'] ?? data['coordinates'];
+  if ((latitude == null || longitude == null) && locationField is GeoPoint) {
+    latitude ??= locationField.latitude;
+    longitude ??= locationField.longitude;
+  } else if ((latitude == null || longitude == null) && locationField is Map) {
+    final Map<dynamic, dynamic> locationMap = locationField;
+    latitude ??=
+        _toDouble(locationMap['lat'] ?? locationMap['latitude'] ?? locationMap['y']);
+    longitude ??=
+        _toDouble(locationMap['lng'] ?? locationMap['longitude'] ?? locationMap['long'] ?? locationMap['x']);
+  }
+
+  if (latitude == null || longitude == null) {
+    return null;
+  }
+
+  final DateTime? lastUpdated = _parseTimestamp(
+    data['updatedAt'] ??
+        data['lastUpdated'] ??
+        data['timestamp'] ??
+        data['lastSeen'] ??
+        data['lastLocationUpdate'],
+  );
+
+  final dynamic sharedIdValue =
+      data['sharedUserId'] ?? data['userId'] ?? data['uid'] ?? data['calleeId'];
+
+  return RemoteLocationData(
+    latitude: latitude,
+    longitude: longitude,
+    lastUpdated: lastUpdated,
+    sharedUserId: sharedIdValue is String ? sharedIdValue : null,
+  );
+}
+
+Future<DocumentSnapshot<Map<String, dynamic>>?> _getDocIfExists(
+  CollectionReference<Map<String, dynamic>> collection,
+  String docId,
+) async {
+  if (docId.isEmpty) {
+    return null;
+  }
+
+  try {
+    final doc = await collection.doc(docId).get();
+    if (doc.exists) {
+      return doc;
+    }
+  } on FirebaseException catch (error) {
+    debugPrint(
+      'Firestore document lookup failed for $docId in ${collection.path}: ${error.message}',
+    );
+  }
+
+  return null;
+}
+
+Future<DocumentSnapshot<Map<String, dynamic>>?> _queryForField(
+  CollectionReference<Map<String, dynamic>> collection,
+  String field,
+  String value,
+) async {
+  if (value.isEmpty) {
+    return null;
+  }
+
+  try {
+    final querySnapshot =
+        await collection.where(field, isEqualTo: value).limit(1).get();
+    if (querySnapshot.docs.isNotEmpty) {
+      return querySnapshot.docs.first;
+    }
+  } on FirebaseException catch (error) {
+    debugPrint(
+      'Firestore query failed for $field=$value in ${collection.path}: ${error.message}',
+    );
+  }
+
+  return null;
+}
+
+Future<RemoteLocationData?> fetchRemoteLocationForPhone(
+  String phoneNumber, {
+  String? sharedUserId,
+}) async {
+  final String trimmed = phoneNumber.trim();
+  final String sanitized = _sanitizePhoneNumber(trimmed);
+
+  final List<String> candidateDocIds = <String>{
+    if (sharedUserId != null && sharedUserId.isNotEmpty) sharedUserId,
+    if (trimmed.isNotEmpty) trimmed,
+    if (sanitized.isNotEmpty) sanitized,
+  }.toList();
+
+  for (final collectionName in _remoteLocationCollections) {
+    final collection = FirebaseFirestore.instance.collection(collectionName);
+
+    for (final candidate in candidateDocIds) {
+      final doc = await _getDocIfExists(collection, candidate);
+      if (doc != null) {
+        final result = _documentToRemoteLocation(doc);
+        if (result != null) {
+          return result;
+        }
+      }
+    }
+
+    DocumentSnapshot<Map<String, dynamic>>? queriedDoc;
+    final Set<String> attemptedQueries = <String>{};
+
+    Future<DocumentSnapshot<Map<String, dynamic>>?> runQuery(
+      String field,
+      String value,
+    ) {
+      if (value.isEmpty) {
+        return Future<DocumentSnapshot<Map<String, dynamic>>?>.value(null);
+      }
+      final signature = '$field::$value';
+      if (!attemptedQueries.add(signature)) {
+        return Future<DocumentSnapshot<Map<String, dynamic>>?>.value(null);
+      }
+      return _queryForField(collection, field, value);
+    }
+
+    if (sharedUserId != null && sharedUserId.isNotEmpty) {
+      queriedDoc = await runQuery('sharedUserId', sharedUserId) ??
+          await runQuery('userId', sharedUserId) ??
+          await runQuery('uid', sharedUserId) ??
+          await runQuery('calleeId', sharedUserId);
+    }
+
+    if (queriedDoc == null && trimmed.isNotEmpty) {
+      queriedDoc = await runQuery('phoneNumber', trimmed) ??
+          await runQuery('normalizedPhoneNumber', trimmed);
+    }
+
+    if (queriedDoc == null && sanitized.isNotEmpty && sanitized != trimmed) {
+      queriedDoc = await runQuery('phoneNumber', sanitized) ??
+          await runQuery('normalizedPhoneNumber', sanitized);
+    }
+
+    if (queriedDoc != null) {
+      final result = _documentToRemoteLocation(queriedDoc);
+      if (result != null) {
+        return result;
+      }
+    }
+  }
+
+  return null;
+}
+
+Future<void> persistRemoteLocation(
+  RemoteLocationData data, {
+  SharedPreferences? prefs,
+}) async {
+  final SharedPreferences store = prefs ?? await SharedPreferences.getInstance();
+  await store.setDouble(_prefsRemoteLatKey, data.latitude);
+  await store.setDouble(_prefsRemoteLngKey, data.longitude);
+  if (data.lastUpdated != null) {
+    await store.setString(
+      _prefsRemoteUpdatedAtKey,
+      data.lastUpdated!.toIso8601String(),
+    );
+  } else {
+    await store.remove(_prefsRemoteUpdatedAtKey);
+  }
+
+  final String? sharedId = data.sharedUserId;
+  if (sharedId != null && sharedId.isNotEmpty) {
+    await store.setString(_prefsRemoteSharedUserIdKey, sharedId);
+  } else {
+    await store.remove(_prefsRemoteSharedUserIdKey);
+  }
+}
+
+Future<RemoteLocationData?> readPersistedRemoteLocation({
+  SharedPreferences? prefs,
+}) async {
+  final SharedPreferences store = prefs ?? await SharedPreferences.getInstance();
+  return _remoteLocationFromPrefs(store);
+}
+
+RemoteLocationData? _remoteLocationFromPrefs(SharedPreferences prefs) {
+  final double? lat = prefs.getDouble(_prefsRemoteLatKey);
+  final double? lng = prefs.getDouble(_prefsRemoteLngKey);
+  if (lat == null || lng == null) {
+    return null;
+  }
+  final String? updatedAtIso = prefs.getString(_prefsRemoteUpdatedAtKey);
+  final DateTime? updatedAt =
+      updatedAtIso != null ? DateTime.tryParse(updatedAtIso) : null;
+  final String? sharedId = prefs.getString(_prefsRemoteSharedUserIdKey);
+  return RemoteLocationData(
+    latitude: lat,
+    longitude: lng,
+    lastUpdated: updatedAt,
+    sharedUserId: sharedId,
+  );
+}
+
+String _formatTimestamp(DateTime? timestamp) {
+  if (timestamp == null) {
+    return 'unknown';
+  }
+  final DateTime local = timestamp.toLocal();
+  String twoDigits(int value) => value.toString().padLeft(2, '0');
+  return '${local.year}-${twoDigits(local.month)}-${twoDigits(local.day)} '
+      '${twoDigits(local.hour)}:${twoDigits(local.minute)}';
+}
+
 // Main App
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
@@ -92,6 +457,118 @@ class _CallSchedulerScreenState extends State<CallSchedulerScreen> {
   String _locationMessage = "📍 Location not fetched";
   LatLng? _currentLatLng;
   bool _isFetchingLocation = false;
+  bool _isLoadingRemoteLocation = false;
+  String? _sharedRemoteUserId;
+
+  @override
+  void initState() {
+    super.initState();
+    _restoreCachedRemoteLocation();
+  }
+
+  Future<void> _restoreCachedRemoteLocation() async {
+    final RemoteLocationData? cached = await readPersistedRemoteLocation();
+    if (cached == null || !mounted) {
+      return;
+    }
+
+    setState(() {
+      _currentLatLng = LatLng(cached.latitude, cached.longitude);
+      _locationMessage =
+          "📍 Cached remote: Lat ${cached.latitude.toStringAsFixed(5)}, Lng ${cached.longitude.toStringAsFixed(5)}";
+      _sharedRemoteUserId = cached.sharedUserId ?? _sharedRemoteUserId;
+    });
+  }
+
+  Future<RemoteLocationData?> _loadRemoteLocation(String phoneNumber) async {
+    final String trimmedNumber = phoneNumber.trim();
+    if (trimmedNumber.isEmpty) {
+      setState(() {
+        _locationMessage = '⚠️ Enter a phone number to fetch remote location';
+        _currentLatLng = null;
+      });
+      return null;
+    }
+
+    setState(() {
+      _isLoadingRemoteLocation = true;
+      _locationMessage = '📡 Loading remote location…';
+    });
+
+    try {
+      final SharedPreferences prefs = await SharedPreferences.getInstance();
+      final RemoteLocationData? cached = await readPersistedRemoteLocation(prefs: prefs);
+      final String? storedSharedId =
+          prefs.getString(_prefsRemoteSharedUserIdKey) ?? _sharedRemoteUserId;
+
+      final RemoteLocationData? remoteLocation = await fetchRemoteLocationForPhone(
+        trimmedNumber,
+        sharedUserId: storedSharedId,
+      );
+
+      if (!mounted) {
+        return remoteLocation ?? cached;
+      }
+
+      if (remoteLocation == null) {
+        if (cached != null) {
+          setState(() {
+            _isLoadingRemoteLocation = false;
+            _currentLatLng = LatLng(cached.latitude, cached.longitude);
+            _locationMessage =
+                '⚠️ Unable to refresh remote location – showing cached data (last update ${_formatTimestamp(cached.lastUpdated)})';
+            _sharedRemoteUserId =
+                cached.sharedUserId ?? storedSharedId ?? _sharedRemoteUserId;
+          });
+          return cached;
+        }
+
+        setState(() {
+          _isLoadingRemoteLocation = false;
+          _currentLatLng = null;
+          _locationMessage =
+              '⚠️ No remote location available for $trimmedNumber';
+        });
+        return null;
+      }
+
+      await persistRemoteLocation(remoteLocation, prefs: prefs);
+
+      final String message = remoteLocation.isStale
+          ? '⚠️ Remote location may be stale (last update ${_formatTimestamp(remoteLocation.lastUpdated)})'
+          : '📍 Remote: Lat ${remoteLocation.latitude.toStringAsFixed(5)}, Lng ${remoteLocation.longitude.toStringAsFixed(5)}';
+
+      setState(() {
+        _isLoadingRemoteLocation = false;
+        _currentLatLng = LatLng(remoteLocation.latitude, remoteLocation.longitude);
+        _locationMessage = message;
+        _sharedRemoteUserId =
+            remoteLocation.sharedUserId ?? storedSharedId ?? _sharedRemoteUserId;
+      });
+
+      if (remoteLocation.isStale) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              '⚠️ Remote location may be stale. Last update ${_formatTimestamp(remoteLocation.lastUpdated)}',
+            ),
+          ),
+        );
+      }
+
+      return remoteLocation;
+    } catch (error) {
+      debugPrint('Failed to load remote location for $trimmedNumber: $error');
+      if (!mounted) {
+        return null;
+      }
+      setState(() {
+        _isLoadingRemoteLocation = false;
+        _locationMessage = '⚠️ Failed to load remote location';
+      });
+      return null;
+    }
+  }
 
   // Pick time
   Future<void> _pickTime() async {
@@ -150,6 +627,9 @@ class _CallSchedulerScreenState extends State<CallSchedulerScreen> {
       return;
     }
 
+    final RemoteLocationData? remoteLocation =
+        await _loadRemoteLocation(_phoneController.text);
+
     final now = DateTime.now();
     final scheduleTime = DateTime(
       now.year,
@@ -163,12 +643,28 @@ class _CallSchedulerScreenState extends State<CallSchedulerScreen> {
     final delay =
         duration.isNegative ? duration + const Duration(days: 1) : duration;
 
+    final Map<String, dynamic> alarmParams = {
+      'phoneNumber': _phoneController.text,
+    };
+
+    if (remoteLocation != null) {
+      alarmParams['remoteLat'] = remoteLocation.latitude;
+      alarmParams['remoteLng'] = remoteLocation.longitude;
+      if (remoteLocation.sharedUserId != null &&
+          remoteLocation.sharedUserId!.isNotEmpty) {
+        alarmParams['sharedUserId'] = remoteLocation.sharedUserId;
+      }
+    } else if (_sharedRemoteUserId != null &&
+        _sharedRemoteUserId!.isNotEmpty) {
+      alarmParams['sharedUserId'] = _sharedRemoteUserId;
+    }
+
     final alarmId = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     await AndroidAlarmManager.oneShot(
       delay,
       alarmId,
       _triggerCall,
-      params: {'phoneNumber': _phoneController.text},
+      params: alarmParams,
     );
 
     if (!mounted) return;
@@ -238,7 +734,9 @@ class _CallSchedulerScreenState extends State<CallSchedulerScreen> {
             SizedBox(height: 220, child: _buildMapPreview()),
             const SizedBox(height: 20),
             ElevatedButton.icon(
-              onPressed: _scheduleCall,
+              onPressed: (_isFetchingLocation || _isLoadingRemoteLocation)
+                  ? null
+                  : _scheduleCall,
               icon: const Icon(Icons.schedule),
               label: const Text("Schedule Call"),
             ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,11 +35,13 @@ dependencies:
 
   url_launcher: ^6.3.2
   cloud_firestore: ^6.0.2
+  firebase_core: ^3.4.0
   permission_handler: ^12.0.1
   geolocator: ^14.0.2
   geocoding: ^4.0.0
   flutter_map: ^6.1.0
   latlong2: ^0.9.1
+  shared_preferences: ^2.3.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- initialize Firebase at startup and add shared preferences support for persisting remote coordinates
- fetch the callee's latest location from Firestore with stale-data handling and update the scheduler UI/map before scheduling a call
- store the fetched coordinates for reuse when the background alarm fires so `_triggerCall` can log or reuse the last known location

## Testing
- Not run (Flutter SDK is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68daabaa3574832c9e5b8bda5ced2f14