### PR TITLE
Ensure main entry point returns Future

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,7 +9,7 @@ import 'package:geolocator/geolocator.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:permission_handler/permission_handler.dart';
 
-void main() async {
+Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp();
   await AndroidAlarmManager.initialize();


### PR DESCRIPTION
## Summary
- update the application entry point to return `Future<void>` so the awaited Firebase initialization occurs in an async context

## Testing
- flutter analyze *(fails: Flutter SDK is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dab5286d80832c8fdda9e4f471f90d