### PR TITLE
Consolidate CallScheduler initState

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -471,6 +471,8 @@ class _CallSchedulerScreenState extends State<CallSchedulerScreen> {
   void initState() {
     super.initState();
     _restoreCachedRemoteLocation();
+    unawaited(LocationSyncService.instance
+        .start(userId: LocationSyncService.defaultUserId));
   }
 
   Future<void> _restoreCachedRemoteLocation() async {
@@ -575,13 +577,6 @@ class _CallSchedulerScreenState extends State<CallSchedulerScreen> {
       });
       return null;
     }
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    unawaited(LocationSyncService.instance
-        .start(userId: LocationSyncService.defaultUserId));
   }
 
   // Pick time


### PR DESCRIPTION
## Summary
- merge the duplicate initState overrides in _CallSchedulerScreenState into a single method
- ensure both restoring cached remote locations and starting the LocationSyncService occur during initialization

## Testing
- flutter analyze *(fails: `flutter` command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dae34a23ec832c90d974df109281ad