### PR TITLE
Import LocationSyncService in main

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,8 @@ import 'package:geolocator/geolocator.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:permission_handler/permission_handler.dart';
 
+import 'location_sync_service.dart';
+
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp();


### PR DESCRIPTION
## Summary
- add the missing `location_sync_service.dart` import to `main.dart` so `LocationSyncService` resolves

## Testing
- flutter analyze *(fails: flutter command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dae34a8898832c8607979f05cdec0c