### PR TITLE
Add missing shared preferences and URL launcher imports

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,8 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();


### PR DESCRIPTION
## Summary
- add the shared_preferences and url_launcher package imports to main.dart
- ensure the imports appear alongside the other package imports so that existing usages resolve

## Testing
- flutter analyze *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dae34b1df8832caf4d5b9de5b0ae44