### PR TITLE
Add injectable interface for location syncing

### DIFF
--- a/lib/location_sync_service.dart
+++ b/lib/location_sync_service.dart
@@ -8,10 +8,17 @@ import 'package:flutter/widgets.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:permission_handler/permission_handler.dart';
 
+/// Contract used by UI code to coordinate location syncing.
+abstract class LocationSyncClient {
+  Future<void> start({required String userId});
+
+  Future<void> pushPosition(Position position);
+}
+
 /// A singleton service that keeps the user's location in sync with Firestore
 /// and schedules periodic background updates so other devices know the last
 /// reported position.
-class LocationSyncService {
+class LocationSyncService implements LocationSyncClient {
   LocationSyncService._internal();
 
   /// Default user id used for demo purposes. Replace with an authenticated id

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -6,14 +6,31 @@
 // tree, read text, and verify that the values of widget properties are correct.
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:girlfriend_call_app/location_sync_service.dart';
 import 'package:girlfriend_call_app/main.dart';
 
+class _FakeLocationSyncClient implements LocationSyncClient {
+  @override
+  Future<void> start({required String userId}) async {}
+
+  @override
+  Future<void> pushPosition(Position position) async {}
+}
+
 void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
   testWidgets('Call scheduler UI renders expected defaults',
       (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(
+      MyApp(locationSyncClient: _FakeLocationSyncClient()),
+    );
 
     // Verify the main scaffolding and default field text.
     expect(find.text('📞 Call Reminder + Location'), findsOneWidget);


### PR DESCRIPTION
## Summary
- add a `LocationSyncClient` contract and implement it in `LocationSyncService`
- inject the location sync dependency through `MyApp` and `CallSchedulerScreen`
- update the widget test to use a fake client and mock shared preferences

## Testing
- ⚠️ `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68daebf0b1b0832cbc81f5b35392cd68